### PR TITLE
Update hf.py

### DIFF
--- a/faithfulrag/llm/hf.py
+++ b/faithfulrag/llm/hf.py
@@ -152,6 +152,7 @@ async def hf_chat_completion(
     
     generation_params.pop("hashing_kv", None)
     generation_params.pop("keyword_extraction", None)
+    generation_params.pop("max_tokens", None)
     
     params.update(generation_params)
     


### PR DESCRIPTION
fix bug.
ValueError: The following `model_kwargs` are not used by the model: ['max_tokens'] (note: typos in the generate arguments will also show up in this list)